### PR TITLE
[Feature] editPage, createPage

### DIFF
--- a/src/components/ArticleForm.tsx
+++ b/src/components/ArticleForm.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import useInputs from '../hooks/useInputs';
+import TagList, { type TagItem } from '../pages/CreatePage/TagList';
+import defaultArticleObj from '../pages/EditPage/DefaultValues';
+import { type DefaultArticleProps, type FormFields } from '../types/article';
+
+interface ArticleFormProps {
+  onFormSubmit: (form: FormFields, tagList: TagItem[]) => Promise<void>;
+
+  /*
+  그러나 ESLint 규칙은 이 형태의 기본 prop 할당을 인식하지 못하며, 대신에 defaultProps의 사용을 기대합니다. defaultProps는 레거시 기능이며 TypeScript의 엄격한 널 체크와 잘 작동하지 않을 수 있기 때문에, TypeScript에서는 당신이 하고 있는 것처럼 기본 매개변수를 사용하는 것이 선호됩니다.
+  */
+  // eslint-disable-next-line react/require-default-props
+  defaultArticle?: DefaultArticleProps;
+}
+
+function ArticleForm({
+  onFormSubmit,
+  defaultArticle = defaultArticleObj,
+}: ArticleFormProps): JSX.Element {
+  const { form, onChange, setValues } = useInputs({
+    title: defaultArticle.title,
+    description: defaultArticle.description,
+    body: defaultArticle.body,
+  });
+  const { title, description, body } = form;
+  const [tag, setTag] = useState('');
+  const [tagList, setTagList] = useState<TagItem[]>([]);
+
+  useEffect(() => {
+    setValues(defaultArticle);
+    setTagList(
+      defaultArticle.tagList.map((tagValue) => ({
+        tag: tagValue,
+        id: uuidv4(),
+      })),
+    );
+  }, [defaultArticle]);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    onFormSubmit(form, tagList).catch((err) => {
+      console.error(err);
+    });
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    setTag(e.target.value);
+  };
+
+  const handleFormKeyDown = (
+    event: React.KeyboardEvent<HTMLInputElement>,
+  ): void => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+    }
+  };
+
+  const onRemoveTag = (id: string): void => {
+    setTagList((prev) => prev.filter((tagItem) => tagItem.id !== id));
+  };
+
+  const handleKeyDown = (
+    event: React.KeyboardEvent<HTMLInputElement>,
+  ): void => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      setTagList((prev) => [{ id: uuidv4(), tag }, ...prev]);
+      setTag('');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <fieldset>
+        <fieldset className="form-group">
+          <input
+            type="text"
+            className="form-control form-control-lg"
+            placeholder="Article Title"
+            name="title"
+            value={title}
+            onChange={onChange}
+            onKeyDown={handleFormKeyDown}
+          />
+        </fieldset>
+        <fieldset className="form-group">
+          <input
+            type="text"
+            className="form-control"
+            placeholder="What's this article about?"
+            name="description"
+            value={description}
+            onChange={onChange}
+            onKeyDown={handleFormKeyDown}
+          />
+        </fieldset>
+        <fieldset className="form-group">
+          <textarea
+            className="form-control"
+            rows={8}
+            placeholder="Write your article (in markdown)"
+            name="body"
+            value={body}
+            onChange={onChange}
+          />
+        </fieldset>
+        <fieldset className="form-group">
+          <input
+            type="text"
+            className="form-control"
+            placeholder="Enter tags"
+            name="tag"
+            value={tag}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+          />
+          <TagList tagList={tagList} onRemoveTag={onRemoveTag} />
+        </fieldset>
+        <button className="btn btn-lg pull-xs-right btn-primary" type="submit">
+          Publish Article
+        </button>
+      </fieldset>
+    </form>
+  );
+}
+
+export default ArticleForm;

--- a/src/components/ShowError.tsx
+++ b/src/components/ShowError.tsx
@@ -1,4 +1,4 @@
-type ErrorObject = Record<string, string>;
+import { type ErrorObject } from '../types/article';
 
 function ShowError(errorObject: ErrorObject): JSX.Element {
   return (

--- a/src/hooks/useInputs.ts
+++ b/src/hooks/useInputs.ts
@@ -5,7 +5,7 @@ function useInputs<T extends Record<string, string>>(
   initialForm: T,
 ): [
   T,
-  (event: React.ChangeEvent<HTMLInputElement>) => void,
+  (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void,
   () => void,
   (name: string, value: string) => void,
   (newState: T) => void,
@@ -18,8 +18,11 @@ function useInputs<T extends Record<string, string>>(
   const onChange = (
     event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ): void => {
+    if (event.target instanceof HTMLInputElement) {
+      const { name, value } = event.target;
+      setForm((preState) => ({ ...preState, [name]: value }));
+    }
     const { name, value } = event.target;
-
     setForm((preState) => ({ ...preState, [name]: value }));
   };
 

--- a/src/hooks/useInputs.ts
+++ b/src/hooks/useInputs.ts
@@ -3,13 +3,15 @@ import { useState, useCallback } from 'react';
 
 function useInputs<T extends Record<string, string>>(
   initialForm: T,
-): [
-  T,
-  (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void,
-  () => void,
-  (name: string, value: string) => void,
-  (newState: T) => void,
-] {
+): {
+  form: T;
+  onChange: (
+    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => void;
+  reset: () => void;
+  setValue: (name: string, value: string) => void;
+  setValues: (newState: T) => void;
+} {
   const [form, setForm] = useState<T>(initialForm);
   const reset = useCallback(() => {
     setForm(initialForm);
@@ -34,7 +36,7 @@ function useInputs<T extends Record<string, string>>(
     setForm((preState) => ({ ...preState, ...newSatate }));
   };
 
-  return [form, onChange, reset, setValue, setValues];
+  return { form, onChange, reset, setValue, setValues };
 }
 
 export default useInputs;

--- a/src/hooks/useInputs.ts
+++ b/src/hooks/useInputs.ts
@@ -15,7 +15,9 @@ function useInputs<T extends Record<string, string>>(
     setForm(initialForm);
   }, [initialForm]);
 
-  const onChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+  const onChange = (
+    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ): void => {
     const { name, value } = event.target;
 
     setForm((preState) => ({ ...preState, [name]: value }));

--- a/src/hooks/useInputs.ts
+++ b/src/hooks/useInputs.ts
@@ -1,27 +1,35 @@
 import type React from 'react';
 import { useState, useCallback } from 'react';
 
-function useInputs<T extends Record<string, any>>(
+function useInputs<T extends Record<string, string>>(
   initialForm: T,
 ): [
   T,
-  (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void,
+  (event: React.ChangeEvent<HTMLInputElement>) => void,
   () => void,
+  (name: string, value: string) => void,
+  (newState: T) => void,
 ] {
   const [form, setForm] = useState<T>(initialForm);
   const reset = useCallback(() => {
     setForm(initialForm);
   }, [initialForm]);
 
-  const onChange = (
-    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-  ): void => {
+  const onChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const { name, value } = event.target;
 
     setForm((preState) => ({ ...preState, [name]: value }));
   };
 
-  return [form, onChange, reset];
+  const setValue = (name: string, value: string): void => {
+    setForm((preState) => ({ ...preState, [name]: value }));
+  };
+
+  const setValues = (newSatate: T): void => {
+    setForm((preState) => ({ ...preState, ...newSatate }));
+  };
+
+  return [form, onChange, reset, setValue, setValues];
 }
 
 export default useInputs;

--- a/src/pages/CreatePage/CreatePage.tsx
+++ b/src/pages/CreatePage/CreatePage.tsx
@@ -1,30 +1,29 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
-import { v4 as uuidv4 } from 'uuid';
+
+import ArticleForm from '../../components/ArticleForm';
 import ShowError from '../../components/ShowError';
-import useInputs from '../../hooks/useInputs';
 import { userInfoAtom } from '../../recoil/recoil_state';
-import createArticles from '../../util/api';
+import { createArticles } from '../../util/api';
 import areAllFieldsFilled from '../../util/formValidation';
-import TagList, { type TagItem } from './TagList';
+import { type TagItem } from './TagList';
 
 function CreatePage(): JSX.Element {
-  const [form, onChange] = useInputs({
-    title: '',
-    description: '',
-    body: '',
-  });
-  const { title, description, body } = form;
-  const [displayError, setDisplayError] = useState({});
+  const [displayError, setDisplayError] = useState<
+    Record<string, string> | undefined
+  >(undefined);
   const userInfo = useRecoilValue(userInfoAtom);
   const navigate = useNavigate();
   const { token } = userInfo.user;
 
-  const [tag, setTag] = useState('');
-  const [tagList, setTagList] = useState<TagItem[]>([]);
+  interface FormFields {
+    title: string;
+    description: string;
+    body: string;
+  }
 
-  const validateForm = (formObj: Record<string, string>): boolean => {
+  const validateForm = (formObj: FormFields): boolean => {
     const { isFilled, errors } = areAllFieldsFilled(formObj);
     if (!isFilled) {
       setDisplayError(errors);
@@ -33,49 +32,23 @@ function CreatePage(): JSX.Element {
     return true;
   };
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
-    e.preventDefault();
-    if (validateForm(form)) {
-      const tags = tagList.map((tagItem) => tagItem.tag);
-      (async () => {
-        const { slug, errors } = await createArticles(
-          { ...form, tagList: tags },
-          token,
-        );
-
-        if (Object.keys(errors).length === 0) {
-          navigate(`/article/${slug}`);
+  const handleSubmit = async (
+    form: FormFields,
+    tagList: TagItem[],
+  ): Promise<void> => {
+    try {
+      if (validateForm(form)) {
+        const tags = tagList.map((tagItem) => tagItem.tag);
+        const formObj = { ...form, tagList: tags };
+        const { slug, errors } = await createArticles(formObj, token);
+        console.log(slug, errors);
+        if (errors === undefined) {
+          navigate(`/article/${slug ?? ''}`);
         }
         setDisplayError(errors);
-      })().catch((submitError) => {
-        console.error(submitError);
-      });
-    }
-  };
-
-  const handleKeyDown = (
-    event: React.KeyboardEvent<HTMLInputElement>,
-  ): void => {
-    if (event.key === 'Enter') {
-      event.preventDefault();
-      setTagList((prev) => [{ id: uuidv4(), tag }, ...prev]);
-      setTag('');
-    }
-  };
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    setTag(e.target.value);
-  };
-
-  const removeTag = (id: string): void => {
-    setTagList((prev) => prev.filter((tagItem) => tagItem.id !== id));
-  };
-
-  const handleFormKeyDown = (
-    event: React.KeyboardEvent<HTMLInputElement>,
-  ): void => {
-    if (event.key === 'Enter') {
-      event.preventDefault();
+      }
+    } catch (error) {
+      console.error(error);
     }
   };
 
@@ -85,65 +58,9 @@ function CreatePage(): JSX.Element {
         <div className="row">
           <div className="col-md-10 offset-md-1 col-xs-12">
             <ul className="error-messages">
-              {!(Object.keys(displayError).length === 0) && (
-                <>{ShowError(displayError)}</>
-              )}
+              {displayError != null && <>{ShowError(displayError)}</>}
             </ul>
-            <form onSubmit={handleSubmit}>
-              <fieldset>
-                <fieldset className="form-group">
-                  <input
-                    type="text"
-                    className="form-control form-control-lg"
-                    placeholder="Article Title"
-                    name="title"
-                    value={title}
-                    onChange={onChange}
-                    onKeyDown={handleFormKeyDown}
-                  />
-                </fieldset>
-                <fieldset className="form-group">
-                  <input
-                    type="text"
-                    className="form-control"
-                    placeholder="What's this article about?"
-                    name="description"
-                    value={description}
-                    onChange={onChange}
-                    onKeyDown={handleFormKeyDown}
-                  />
-                </fieldset>
-                <fieldset className="form-group">
-                  <textarea
-                    className="form-control"
-                    rows={8}
-                    placeholder="Write your article (in markdown)"
-                    name="body"
-                    value={body}
-                    onChange={onChange}
-                  />
-                </fieldset>
-                <fieldset className="form-group">
-                  <input
-                    type="text"
-                    className="form-control"
-                    placeholder="Enter tags"
-                    name="tag"
-                    value={tag}
-                    onChange={handleChange}
-                    onKeyDown={handleKeyDown}
-                  />
-
-                  <TagList tagList={tagList} onRemoveTag={removeTag} />
-                </fieldset>
-                <button
-                  className="btn btn-lg pull-xs-right btn-primary"
-                  type="submit"
-                >
-                  Publish Article
-                </button>
-              </fieldset>
-            </form>
+            <ArticleForm onFormSubmit={handleSubmit} />
           </div>
         </div>
       </div>

--- a/src/pages/EditPage/DefaultValues.ts
+++ b/src/pages/EditPage/DefaultValues.ts
@@ -1,0 +1,21 @@
+import { type DefaultArticleProps } from '../../types/article';
+
+const defaultArticleObj: DefaultArticleProps = {
+  slug: '',
+  title: '',
+  description: '',
+  body: '',
+  tagList: [],
+  createdAt: '',
+  updatedAt: '',
+  favorited: false,
+  favoritesCount: 0,
+  author: {
+    username: '',
+    bio: '',
+    image: '',
+    following: false,
+  },
+};
+
+export default defaultArticleObj;

--- a/src/pages/EditPage/EditPage.tsx
+++ b/src/pages/EditPage/EditPage.tsx
@@ -1,48 +1,91 @@
-function EditPage() {
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import ShowError from '../../components/ShowError';
+import { userInfoAtom } from '../../recoil/recoil_state';
+import { getArticles, updateArticles } from '../../util/api';
+import areAllFieldsFilled from '../../util/formValidation';
+import { type TagItem } from '../CreatePage/TagList';
+import {
+  type FormFields,
+  type ErrorObject,
+  type DefaultArticleProps,
+} from '../../types/article';
+import defaultArticleObj from './DefaultValues';
+import ArticleForm from '../../components/ArticleForm';
+
+function EditPage(): JSX.Element {
+  const [displayError, setDisplayError] = useState<ErrorObject>({});
+  const [article, setArticle] =
+    useState<DefaultArticleProps>(defaultArticleObj);
+  const userInfo = useRecoilValue(userInfoAtom);
+  const navigate = useNavigate();
+  const { slug: updateSlug } = useParams();
+  const { token } = userInfo.user;
+
+  if (updateSlug === undefined) {
+    throw Error();
+  }
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const { article: responseArticle = defaultArticleObj, errors = {} } =
+          await getArticles(token, updateSlug);
+        setDisplayError(errors);
+        setArticle(responseArticle);
+      } catch (error) {
+        console.error(error);
+      }
+    })();
+  }, [updateSlug]);
+
+  const validateForm = (formObj: FormFields): boolean => {
+    const { isFilled, errors } = areAllFieldsFilled(formObj);
+    if (!isFilled) {
+      setDisplayError(errors);
+      return false;
+    }
+    return true;
+  };
+
+  const handleSubmit = async (
+    form: FormFields,
+    tagList: TagItem[],
+  ): Promise<void> => {
+    try {
+      if (updateSlug === undefined) {
+        console.error('No slug provided for update');
+        return;
+      }
+
+      if (validateForm(form)) {
+        const tags = tagList.map((tagItem) => tagItem.tag);
+        const formObj = { ...form, tagList: tags };
+        const { slug, errors = {} } = await updateArticles(
+          formObj,
+          token,
+          updateSlug,
+        );
+        if (Object.keys(errors).length === 0) {
+          navigate(`/article/${slug ?? ''}`);
+        }
+        setDisplayError(errors);
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
   return (
     <div className="editor-page">
       <div className="container page">
         <div className="row">
           <div className="col-md-10 offset-md-1 col-xs-12">
-            <form>
-              <fieldset>
-                <fieldset className="form-group">
-                  <input
-                    type="text"
-                    className="form-control form-control-lg"
-                    placeholder="Article Title"
-                  />
-                </fieldset>
-                <fieldset className="form-group">
-                  <input
-                    type="text"
-                    className="form-control"
-                    placeholder="What's this article about?"
-                  />
-                </fieldset>
-                <fieldset className="form-group">
-                  <textarea
-                    className="form-control"
-                    rows={8}
-                    placeholder="Write your article (in markdown)"
-                  ></textarea>
-                </fieldset>
-                <fieldset className="form-group">
-                  <input
-                    type="text"
-                    className="form-control"
-                    placeholder="Enter tags"
-                  />
-                  <div className="tag-list"></div>
-                </fieldset>
-                <button
-                  className="btn btn-lg pull-xs-right btn-primary"
-                  type="button"
-                >
-                  Publish Article
-                </button>
-              </fieldset>
-            </form>
+            <ul className="error-messages">
+              {displayError != null && <>{ShowError(displayError)}</>}
+            </ul>
+            <ArticleForm onFormSubmit={handleSubmit} defaultArticle={article} />
           </div>
         </div>
       </div>

--- a/src/pages/SettingsPage/SettingsPage.tsx
+++ b/src/pages/SettingsPage/SettingsPage.tsx
@@ -6,7 +6,7 @@ import { userInfoAtom } from '../../recoil/recoil_state';
 function SettingsPage(): JSX.Element {
   const [userInfo, setUserInfo] = useRecoilState(userInfoAtom);
   const userInfoReset = useResetRecoilState(userInfoAtom);
-  const [form, onChange] = useInputs({
+  const { form, onChange } = useInputs({
     image: userInfo.user.image,
     username: userInfo.user.username,
     bio: userInfo.user.bio,

--- a/src/pages/SignInPage/SignInPage.tsx
+++ b/src/pages/SignInPage/SignInPage.tsx
@@ -9,7 +9,10 @@ import isEmpty from '../../util/isEmpty';
 const { VITE_API_URL } = import.meta.env;
 
 function SignInPage(): JSX.Element {
-  const [{ email, password }, onChange] = useInputs({
+  const {
+    form: { email, password },
+    onChange,
+  } = useInputs({
     email: '',
     password: '',
   });

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -7,7 +7,10 @@ import { userInfoAtom, isLoginSelector } from '../../recoil/recoil_state';
 import ShowError from '../../components/ShowError';
 
 function SignUpPage(): JSX.Element {
-  const [{ username, email, password }, onChange] = useInputs({
+  const {
+    form: { username, email, password },
+    onChange,
+  } = useInputs({
     username: '',
     email: '',
     password: '',

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -1,0 +1,30 @@
+interface Author {
+  username: string;
+  bio: string;
+  image: string;
+  following: boolean;
+}
+
+export interface DefaultArticleProps {
+  slug: string;
+  title: string;
+  description: string;
+  body: string;
+  tagList: string[];
+  createdAt: string;
+  updatedAt: string;
+  favorited: boolean;
+  favoritesCount: number;
+  author: Author;
+}
+
+export interface FormFields {
+  title: string;
+  description: string;
+  body: string;
+}
+
+export interface ErrorObject {
+  key?: string;
+  value?: string;
+}

--- a/src/util/api.ts
+++ b/src/util/api.ts
@@ -1,3 +1,5 @@
+import { type DefaultArticleProps } from '../types/article';
+
 interface FormFields {
   title: string;
   description: string;
@@ -10,11 +12,12 @@ const { VITE_API_URL } = import.meta.env;
 type ResponseErrors = Record<string, string>;
 
 interface Response {
-  slug: string;
-  errors: ResponseErrors;
+  article?: DefaultArticleProps;
+  slug?: string;
+  errors?: ResponseErrors;
 }
 
-const createArticles = async (
+export const createArticles = async (
   formObj: FormFields,
   token: string,
 ): Promise<Response> => {
@@ -32,9 +35,10 @@ const createArticles = async (
     const responseData = await response.json();
     if (!response.ok) {
       newError = { ...responseData.errors };
+      return { errors: newError };
     }
     const { slug } = responseData.article;
-    return { slug, errors: newError };
+    return { slug };
   } catch (responseError) {
     if (responseError instanceof Error) {
       throw new Error(responseError.message);
@@ -44,4 +48,63 @@ const createArticles = async (
   }
 };
 
-export default createArticles;
+export const updateArticles = async (
+  formObj: FormFields,
+  token: string,
+  updateSlug: string,
+): Promise<Response> => {
+  try {
+    const data = { article: formObj };
+    let newError: ResponseErrors = {};
+    const response = await fetch(`${VITE_API_URL}/articles/${updateSlug}`, {
+      method: 'put',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+    });
+    const responseData = await response.json();
+    if (!response.ok) {
+      newError = { ...responseData.errors };
+      return { errors: newError };
+    }
+    const { slug } = responseData.article;
+    return { slug };
+  } catch (responseError) {
+    if (responseError instanceof Error) {
+      throw new Error(responseError.message);
+    } else {
+      throw new Error('An unexpected error occurred.');
+    }
+  }
+};
+
+export const getArticles = async (
+  token: string,
+  getSlug: string,
+): Promise<Response> => {
+  try {
+    let newError: ResponseErrors = {};
+    const response = await fetch(`${VITE_API_URL}/articles/${getSlug}`, {
+      method: 'get',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+    const responseData = await response.json();
+    if (!response.ok) {
+      newError = { ...responseData.errors };
+      return { errors: newError };
+    }
+    const { article } = responseData;
+    return { article };
+  } catch (responseError) {
+    if (responseError instanceof Error) {
+      throw new Error(responseError.message);
+    } else {
+      throw new Error('An unexpected error occurred.');
+    }
+  }
+};

--- a/src/util/formValidation.ts
+++ b/src/util/formValidation.ts
@@ -1,6 +1,10 @@
 import isEmpty from './isEmpty';
 
-type FormFields = Record<string, string>;
+interface ValidateFormFields {
+  title: string;
+  description: string;
+  body: string;
+}
 
 type FormErrors = Record<string, string>;
 
@@ -9,12 +13,14 @@ interface ValidationResult {
   errors: FormErrors;
 }
 
-const areAllFieldsFilled = (formObj: FormFields): ValidationResult => {
+const areAllFieldsFilled = (formObj: ValidateFormFields): ValidationResult => {
   let newError: FormErrors = {};
   for (const [key, value] of Object.entries(formObj)) {
-    if (isEmpty(value)) {
-      newError = { ...newError, [key]: "can't be blank" };
-      break;
+    if (key !== 'tagList') {
+      if (isEmpty(value)) {
+        newError = { ...newError, [key]: "can't be blank" };
+        break;
+      }
     }
   }
   return {


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- #5 
### ✨개발 내용
<!-- 개발한 내용을 설명을 적어주세요 -->
createPage와 editPage를 개발했습니다,
```javascript
import type React from 'react';
import { useState, useCallback } from 'react';

function useInputs<T extends Record<string, string>>(
  initialForm: T,
): {
  form: T;
  onChange: (
    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
  ) => void;
  reset: () => void;
  setValue: (name: string, value: string) => void;
  setValues: (newState: T) => void;
} {
  const [form, setForm] = useState<T>(initialForm);
  const reset = useCallback(() => {
    setForm(initialForm);
  }, [initialForm]);

  const onChange = (
    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
  ): void => {
    if (event.target instanceof HTMLInputElement) {
      const { name, value } = event.target;
      setForm((preState) => ({ ...preState, [name]: value }));
    }
    const { name, value } = event.target;
    setForm((preState) => ({ ...preState, [name]: value }));
  };

  const setValue = (name: string, value: string): void => {
    setForm((preState) => ({ ...preState, [name]: value }));
  };

  const setValues = (newSatate: T): void => {
    setForm((preState) => ({ ...preState, ...newSatate }));
  };

  return { form, onChange, reset, setValue, setValues };
}

export default useInputs;
```
- setValue와 setValues 추가로 추후 데이터를 받아 왔을 때 변경할 수 있게 되었습니다
- return을 객체 형태를 하여 사용할 때 필요 없는 변수를 할당하지 않아도 됩니다
- HTMLTextAreaElement을 추가하여 textarea 태그도 사용할 수 있게 되었습니다.


### 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

### 👓 고민 사항(선택)

### 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
